### PR TITLE
fix to display user-agent in log

### DIFF
--- a/lib/posts-handler.js
+++ b/lib/posts-handler.js
@@ -21,7 +21,8 @@ function handle(req, res) {
       console.info(
         `閲覧されました: user: ${req.user}, ` +
         `trackingId: ${cookies.get(trackingIdKey) },` +
-        `remoteAddress: ${req.connection.remoteAddress} `
+        `remoteAddress: ${req.connection.remoteAddress}, ` +
+        `user-agent: ${req.headers['user-agent']}`
       );
       break;
     case 'POST':


### PR DESCRIPTION
ユーザエージェントを閲覧ログに出力できるよう修正
close #20 