### PR TITLE
fix to output delete log

### DIFF
--- a/lib/posts-handler.js
+++ b/lib/posts-handler.js
@@ -62,6 +62,11 @@ function handleDelete(req, res) {
         Post.findById(id).then((post) => {
           if (req.user === post.postedBy) {
             post.destroy().then(() => {
+              console.info(
+                `削除されました: user: ${req.user}, ` +
+                `remoteAddress: ${req.connection.remoteAddress}, ` +
+                `userAgent: ${req.headers['user-agent']} `
+              );
               handleRedirectPosts(req, res);
             });
           }


### PR DESCRIPTION
投稿を削除後にログも出力できるよう修正
close #24 